### PR TITLE
Concept implementation

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,10 +1,94 @@
-
 //! Back-end agnostic keyboard keys.
 
 use std::hash::Hash;
 use std::hash::sip::SipState;
 use std::num::FromPrimitive;
 use std::num::ToPrimitive;
+use {Device, DeviceID, ElementID, Event, Timestamp};
+
+/// 
+pub trait KeyboardDevice: Device {
+    /// Returns the key corresponding to the element.
+    ///
+    /// Returns `None` if the element doesn't match any `Key` in the enum.
+    fn get_mapping(&self, id: &ElementID) -> Option<Key>;
+}
+
+/// An event triggered by a keyboard device.
+#[deriving(Clone, Show)]
+pub enum KeyboardEvent {
+    /// Pressed a keyboard key.
+    KeyPress {
+        /// When the event happened.
+        pub timestamp: Timestamp,
+
+        /// Which device triggered this event.
+        pub device: DeviceID,
+
+        /// Which element triggered this event.
+        pub element: ElementID,
+
+        /// The key that was pressed, or none if unknown.
+        pub key: Option<Key>,
+    },
+
+    /// Released a keyboard key.
+    KeyRelease {
+        /// When the event happened.
+        pub timestamp: Timestamp,
+
+        /// Which device triggered this event.
+        pub device: DeviceID,
+
+        /// Which element triggered this event.
+        pub element: ElementID,
+
+        /// The key that was released, or none if unknown.
+        pub key: Option<Key>,
+    }
+}
+
+impl Event for KeyboardEvent {
+    fn get_timestamp(&self) -> &Timestamp {
+        match self {
+            &KeyPress{ref timestamp, ..} => timestamp,
+            &KeyRelease{ref timestamp, ..} => timestamp
+        }
+    }
+
+    fn get_device_id(&self) -> &DeviceID {
+        match self {
+            &KeyPress{ref device, ..} => device,
+            &KeyRelease{ref device, ..} => device
+        }
+    }
+
+    fn get_element_id(&self) -> &ElementID {
+        match self {
+            &KeyPress{ref element, ..} => element,
+            &KeyRelease{ref element, ..} => element
+        }
+    }
+
+    fn get_element_value(&self) -> f32 {
+        match self {
+            &KeyPress{..} => 1.0,
+            &KeyRelease{..} => 0.0
+        }
+    }
+}
+
+/// Trait for events that can be turned into `KeyboardEvent`s
+pub trait ToKeyboardEvent: Event {
+    /// Turns the event into a keyboard event.
+    fn to_keyboard_event(&self) -> Option<KeyboardEvent>;
+}
+
+impl ToKeyboardEvent for KeyboardEvent {
+    fn to_keyboard_event(&self) -> Option<KeyboardEvent> {
+        Some(self.clone())
+    }
+}
 
 /// Represent a keyboard key.
 #[allow(missing_doc)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,64 +2,203 @@
 #![deny(missing_doc)]
 #![feature(globs)]
 #![feature(struct_variant)]
+#![unstable]
 
-//! A flexible structure for user interactions
-//! to be used in window frameworks and widgets libraries.
+/*!
+A flexible structure for user interactions to be used in window frameworks and widgets libraries.
+
+## Example usage
+
+### Video game
+
+```ignore
+enum Action {
+    MoveLeft,
+    MoveRight,
+    Shoot,
+    Jump
+}
+
+let config: HashMap<(input::DeviceID, input::ElementID), Action> = load_config();
+
+for event in implementation.events() {
+    let key = (event.get_device_id().clone(), event.get_element_id().clone());
+
+    match config.find(key) {
+        Some(MoveLeft) => move_left(),
+        Some(MoveRight) => move_right(),
+        Some(Shoot) => shoot(),
+        Some(Jump) => jump(),
+        None => ()
+    }
+}
+```
+
+### User interface
+
+```ignore
+fn handle_event<E: input::Event>(event: E) {
+    use input::keyboard::ToKeyboardEvent;
+    use input::mouse::ToMouseEvent;
+
+    match event.to_keyboard_event() {
+        Some(input::keyboard::KeyRelease{ref key, ..}) => {
+            dispatch_key(key);
+            return;
+        },
+        _ => ()
+    }
+
+    match event.to_mouse_event() {
+        Some(input::mouse::MouseMove{ref x, ref y, ..}) => {
+            handle_mouse_hover(x, y);
+            return;
+        },
+        Some(input::mouse::MouseRelease{ref button, ..}) if button == Some(input::mouse::Left) => {
+            handle_left_click();
+            return;
+        },
+        _ => ()
+    }
+}
+```
+
+## How to implement this interface
+
+Implementation should provide a compile-time way to obtains objects which implement
+ `keyboard::KeyboardDevice`, or `mouse::MouseDevice`, or `gamepad::GamepadDevice`, etc.
+
+Devices that are known to always exist (for example a keyboard and a mouse on desktop PC,
+ a touch screen on a mobile device, gamepads on console, etc.) should be easy to obtain, for
+ example by providing functions like `get_main_keyboard()`, `get_gamepad_1()`, etc.
+
+The way an implementation provides events is not covered by this library. However events
+ must implement the `Event` trait in addition to the `keyboard::ToKeyboardEvent`,
+ `mouse::ToMouseEvent`, etc. depending on which type of devices may be available on the platform.
+
+Implementations should provide a way for the user to know which device emitted each event (for
+ example by providing a `(&Device, Event)` instead of just an `Event`. This is also out of the
+ scope of this library.
+
+**/
 
 pub mod keyboard;
 pub mod mouse;
 
-/// Models input events.
-#[deriving(Clone)]
-pub enum InputEvent {
-    /// Pressed a keyboard key.
-    KeyPress {
-        /// Keyboard key.
-        pub key: keyboard::Key,
-    },
-    /// Released a keyboard key.
-    KeyRelease {
-        /// Keyboard key.
-        pub key: keyboard::Key,
-    },
-    /// Pressed a mouse button.
-    MousePress {
-        /// Mouse button.
-        pub button: mouse::Button,
-    },
-    /// Released a mouse button.
-    MouseRelease {
-        /// Mouse button.
-        pub button: mouse::Button,
-    },
-    /// Moved mouse cursor.
-    MouseMove {
-        /// x in window coordinates.
-        pub x: f64,
-        /// y in window coordinates.
-        pub y: f64,
-        /// x in drawing coordinates.
-        pub draw_x: f64,
-        /// y in drawing coordinates.
-        pub draw_y: f64,
-    },
-    /// Moved mouse relative, not bounded by cursor.
-    MouseRelativeMove {
-        /// Delta x in window coordinates.
-        pub dx: f64,
-        /// Delta y in window coordinates.
-        pub dy: f64,
-        /// Delta x in drawing coordinates.
-        pub draw_dx: f64,
-        /// Delta y in drawing coordinates.
-        pub draw_dy: f64,
-    },
-    /// Scrolled mouse.
-    MouseScroll {
-        /// Delta x in undefined coordinates.
-        pub dx: f64,
-        /// Delta y in undefined coordinates.
-        pub dy: f64,
-    },
+/// Represents when an event happened.
+/// 
+/// The exact value of this and how it can be used remain to be defined.
+#[deriving(Show, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct Timestamp(u64);
+
+impl Timestamp {
+    /// Returns the number of nanoseconds since an undefined epoch.
+    #[experimental = "May be removed"]
+    pub fn as_nanoseconds(&self) -> u64 {
+        let &Timestamp(val) = self;
+        val
+    }
 }
 
+/// Object which provides informations about a specific device.
+pub trait Device {
+    /// Returns the ID of this device.
+    fn get_device_id(&self) -> &DeviceID;
+
+    /// Returns the list of elements (ie. buttons and axes) on this device.
+    fn get_elements(&self) -> &[Element];
+
+    /// Returns the human-friendly name of the device.
+    fn get_human_friendly_name(&self) -> &str;
+
+    /// Returns the value of an element.
+    /// 
+    /// For absolute axes, the value is within the given range. For relative axes, the value
+    ///  is arbitrary. For buttons, the value is either 0 (released) or 1 (pressed).
+    fn get_value(&self, &ElementID) -> f32;
+}
+
+/// Represents an identifier for a device on the system.
+///
+/// Each device must have a different `DeviceID`. Two identical devices should provide the same
+///  `DeviceID`.
+///
+/// The `DeviceID` should be persitant. If you store its value in a file, then quit the program,
+///  relaunch it, and reload the value, it should still match the same device.
+///
+/// The exact value is platform-specific and thus implementation-defined.
+#[deriving(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Show)]
+pub struct DeviceID(pub String);
+
+/// Represents an identifier of an element on a device.
+///
+/// The exact value is implementation-defined. For keyboards, this is usually the scancode of
+///  the key.
+#[deriving(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Show)]
+pub struct ElementID(pub u64);
+
+/// Trait for an event produced by a device.
+pub trait Event {
+    /// Returns the moment when the event happened.
+    fn get_timestamp(&self) -> &Timestamp;
+
+    /// Return which device triggered this event.
+    fn get_device_id(&self) -> &DeviceID;
+
+    /// Return which element triggered this event.
+    fn get_element_id(&self) -> &ElementID;
+
+    /// Returns the new value of the element.
+    /// 
+    /// For absolute axes, the value is within the given range. For relative axes, the value
+    ///  is arbitrary. For buttons, the value is either 0 (released) or 1 (pressed).
+    fn get_element_value(&self) -> f32;
+}
+
+/// An element of a device. For example a button.
+pub enum Element {
+    /// An axis which produces absolute values.
+    ///
+    /// Example: the axes of a joystick.
+    AbsoluteAxis {
+        /// Identifier for this element on the device.
+        pub id: ElementID,
+
+        /// The human-friendly name of this element.
+        pub name: String,
+
+        /// Minimum and maximum values of the axis.
+        pub range: (f32, f32),
+    },
+
+    /// An axis which produces relative values.
+    ///
+    /// Example: an accelerometer, the axes of a mouse.
+    RelativeAxis {
+        /// Identifier for this element on the device.
+        pub id: ElementID,
+
+        /// The human-friendly name of this element.
+        pub name: String,
+    },
+
+    /// A button which can be either pressed or released.
+    ///
+    /// Example: mouse buttons, keyboard keys.
+    Button {
+        /// Identifier for this element on the device.
+        pub id: ElementID,
+
+        /// The human-friendly name of this element.
+        pub name: String,
+    },
+
+    /// An element of unspecified type.
+    ///
+    /// This can be used for "system" elements that produce events but that are neither axes
+    ///  nor buttons.
+    UnknownElement {
+        /// Identifier for this element on the device.
+        pub id: ElementID,
+    },
+}

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,11 +1,145 @@
-
 //! Back-end agnostic mouse buttons.
+
+use {Device, DeviceID, ElementID, Event, Timestamp};
+
+/// An object that represents a mouse.
+pub trait MouseDevice: Device {
+    /// Returns the position of the cursor on the surface.
+    ///
+    /// The value is the (x, y) coordinates in pixels relative to the top-left hand corner
+    ///  of the surface.
+    fn get_cursor_position(&self) -> (i16, i16);
+}
+
+/// An event triggered by a mouse device.
+#[deriving(Clone, Show)]
+pub enum MouseEvent {
+    /// Pressed a mouse button.
+    MousePress {
+        /// When the event happened.
+        pub timestamp: Timestamp,
+
+        /// Which device triggered this event.
+        pub device: DeviceID,
+
+        /// Which button triggered this event.
+        pub element: ElementID,
+
+        /// The meaning of the button if known.
+        pub button: Option<Button>,
+    },
+
+    /// Released a mouse button.
+    MouseRelease {
+        /// When the event happened.
+        pub timestamp: Timestamp,
+
+        /// Which device triggered this event.
+        pub device: DeviceID,
+
+        /// Which button triggered this event.
+        pub element: ElementID,
+
+        /// The meaning of the button if known.
+        pub button: Option<Button>,
+    },
+
+    /// Moved mouse cursor.
+    MouseMove {
+        /// When the event happened.
+        pub timestamp: Timestamp,
+        /// Which device triggered this event.
+        pub device: DeviceID,
+        /// Which axis triggered this event.
+        pub element: ElementID,
+        /// x in window coordinates.
+        pub x: f64,
+        /// y in window coordinates.
+        pub y: f64,
+        /// x in drawing coordinates.
+        pub draw_x: f64,
+        /// y in drawing coordinates.
+        pub draw_y: f64,
+        /// Delta x in window coordinates.
+        pub delta_x: f64,
+        /// Delta y in window coordinates.
+        pub delta_y: f64,
+        /// Delta x in drawing coordinates.
+        pub draw_delta_x: f64,
+        /// Delta y in drawing coordinates.
+        pub draw_delta_y: f64,
+    },
+
+    /// Scrolled mouse.
+    MouseScroll {
+        /// When the event happened.
+        pub timestamp: Timestamp,
+        /// Which device triggered this event.
+        pub device: DeviceID,
+        /// Which axis triggered this event.
+        pub element: ElementID,
+        /// x.
+        pub x: f64,
+        /// y.
+        pub y: f64,
+    }
+}
+
+impl Event for MouseEvent {
+    fn get_timestamp(&self) -> &Timestamp {
+        match self {
+            &MousePress{ref timestamp, ..} => timestamp,
+            &MouseRelease{ref timestamp, ..} => timestamp,
+            &MouseMove{ref timestamp, ..} => timestamp,
+            &MouseScroll{ref timestamp, ..} => timestamp
+        }
+    }
+
+    fn get_device_id(&self) -> &DeviceID {
+        match self {
+            &MousePress{ref device, ..} => device,
+            &MouseRelease{ref device, ..} => device,
+            &MouseMove{ref device, ..} => device,
+            &MouseScroll{ref device, ..} => device
+        }
+    }
+
+    fn get_element_id(&self) -> &ElementID {
+        match self {
+            &MousePress{ref element, ..} => element,
+            &MouseRelease{ref element, ..} => element,
+            &MouseMove{ref element, ..} => element,
+            &MouseScroll{ref element, ..} => element
+        }
+    }
+
+    fn get_element_value(&self) -> f32 {
+        match self {
+            &MousePress{..} => 1.0,
+            &MouseRelease{..} => 0.0,
+            &MouseMove{delta_x, delta_y, ..} =>
+                if delta_x != 0.0 { delta_x as f32 } else { delta_y as f32 },
+            &MouseScroll{x, y, ..} =>
+                if x != 0.0 { x as f32 } else { y as f32 },
+        }
+    }
+}
+
+/// Trait for events that can be turned into `MouseEvent`s.
+pub trait ToMouseEvent: Event {
+    /// Turns the event into a mouse event.
+    fn to_mouse_event(&self) -> Option<MouseEvent>;
+}
+
+impl ToMouseEvent for MouseEvent {
+    fn to_mouse_event(&self) -> Option<MouseEvent> {
+        Some(self.clone())
+    }
+}
 
 /// Represent a mouse button.
 #[deriving(Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Show)]
 pub enum Button {
-    /// Unknown mouse button.
-    Unknown,
     /// Left mouse button.
     Left,
     /// Right mouse button.
@@ -16,12 +150,4 @@ pub enum Button {
     X1,
     /// Extra mouse button number 2.
     X2,
-    /// Mouse button number 6.
-    Button6,
-    /// Mouse button number 7.
-    Button7,
-    /// Mouse button number 8.
-    Button8,
 }
-
-


### PR DESCRIPTION
Here is a summary of the implementation that I'd propose for this crate.

The library contains two main traits: `Device` and `Event`.
# Devices

An implementation of this library (for example `gl-init` or `glfw-rs`) should provide a way to obtain the list of devices available on the system. The exact way is implementation-specific. For example for `glfw`, you could simply add the functions `get_mouses()`, `get_keyboards()` and `get_gamepads()`.

When an object that implements `Device` is also a keyboard, it should also implement the `KeyboardDevice` trait, defined in the `keyboard` mod. When a device is also a mouse, it should also implement the `MouseDevice` trait, defined in the `mouse` mod. Same for other kind of devices (gamepad, touch screen, kinect, etc.).

These "more precise" traits (`KeyboardDevice`, `MouseDevice`, etc.) allows one to get more specific informations: what is the state of a key, what is the position of the cursor on the screen, etc.

_Defect_: there is currently no way to get the type of a device if you don't know it at compile-time. For example if a system can have both keyboards and gamepads, you need to provide `get_keyboards()` and `get_gamepads()` instead of just `get_devices()`. Associated types will solve this.
# Events

An implementation should also provide objects which represent input events, and which must implement the `Event` trait.
The exact way that events are provided is implementation specific.
For example for `gl-init`, I would return a list of what happened in the last frame, and one of the things that can happen is an input event. For a more complex implementation you could imaging having a per-device `Sender<Event>`.

The `Event` trait allows one to retrieve all the raw informations about an event, ie. which device produced it, which element of the device, and what is the new "value" of the element.
But if you want more informations about an event, you can import either the `ToKeyboardEvent` trait or the `ToMouseEvent` trait, which allow you to turn, if possible, the event into a `KeyboardEvent` or a `MouseEvent`.

`KeyboardEvent` and `MouseEvent` are simple enums that are easier to manipulate.
# Modular

This design is modular. If you want to manipulate raw events, you can just get a list of `Device`s, and receive `Event`s.

If you want to use the keyboard, just use the `input::keyboard` module which contains the  definitions for `KeyboardDevice`, `KeyboardEvent` and `ToKeyboardEvent`.

For the moment I have only added the `keyboard` and `mouse` modules, but other modules can be added in the future: kinect, touch screen, wiimote, gamepad, etc. One could even implement its own device type outside of the library, if necessary.
