### PR TITLE
Remove redundant Copy trait derivation

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -13,7 +13,7 @@ use Button;
 bitflags!(
     #[deriving(Show)]
     #[allow(missing_docs)]
-    #[deriving(Copy, Decodable, Encodable)]
+    #[deriving(Decodable, Encodable)]
     flags ModifierKey: u8 {
         const NO_MODIFIER           = 0b00000000,
         const CTRL                  = 0b00000001,


### PR DESCRIPTION
Makes the build pass on `rustc 0.13.0-nightly (126db549b 2014-12-15 00:07:35 +0000)`
